### PR TITLE
Extend the char array to allow multi digit  values

### DIFF
--- a/src/Datapoint.cpp
+++ b/src/Datapoint.cpp
@@ -200,7 +200,7 @@ void ModeDP::callback(uint8_t value[]) {
     _callback(_name, _group, value[0]);
   }
   else if (_globalCallback) {
-    char str[2] = {'\0'};
+    char str[4] = {'\0'};
     snprintf(str, sizeof(str), "%u", value[0]);
     _globalCallback(_name, _group, str);
   }

--- a/src/Datapoint.cpp
+++ b/src/Datapoint.cpp
@@ -200,7 +200,8 @@ void ModeDP::callback(uint8_t value[]) {
     _callback(_name, _group, value[0]);
   }
   else if (_globalCallback) {
-    char str[4] = {'\0'};
+    char str[4] = {'\0'};  //4 instead of 2 to allow reuse DP for setting temp to 1-byte-temp-dp
+                           //to do: add and rearrange DPs
     snprintf(str, sizeof(str), "%u", value[0]);
     _globalCallback(_name, _group, str);
   }


### PR DESCRIPTION
Got the temperature setting to work with minimal changes. The catch is that the commands I used (0x2306 for room temp and 0x6300 for hot water temp) operate on temperature differently than the other datapoints handled by the TEMP datapoint type:
- TEMP is a 2 byte floating point value multiplied by 10 (so 0x1400 == 2,0)
- 0x2306 is a 1 byte int storing the temp directly (so 0x14 == 20) - I'm reusing the MODE datapoint type (#define TEMP_1B  MODE) - this is why I needed to extend the char array
- 0x6300 is a 2 byte int storring the temp directly (so 0x1400 == 20) - I'm reusing the COUNTS datapoint type (#define TEMP_INT COUNTS).

It might be prettier to actually extend the enum in the future - adding the 2 new DataPoint types and just reusing ModeDP and CountSDP internally - but that is a decision I don't feel comfortable making on my own, and the code is enough to get me through the winter ;)