### PR TITLE
timeout and rawoptolink example fix

### DIFF
--- a/examples/rawOptolink/rawOptolink.ino
+++ b/examples/rawOptolink/rawOptolink.ino
@@ -52,7 +52,7 @@ void onData(uint8_t* data, uint8_t len, void* index) {
   Serial1.print("\n");
 }
 
-void onData(uint8_t error, void* arg) {
+void onError(uint8_t error, void* arg) {
   Serial1.print(datapoints[(size_t)arg].name);
   Serial1.print(": error ");
   Serial1.println(error);
@@ -62,6 +62,7 @@ void setup() {
   Serial1.begin(115200);
 
   myOptolink.onData(onData);
+  myOptolink.onError(onError);
   myOptolink.begin();
 }
 

--- a/src/OptolinkP300.cpp
+++ b/src/OptolinkP300.cpp
@@ -94,7 +94,7 @@ void OptolinkP300::loop() {
     // begin() not called
     break;
   }
-  if (_queue.size() > 0 && millis() - _lastMillis > 2000UL) {  // if no ACK is coming, reset connection
+  if (_queue.size() > 0 && millis() - _lastMillis > 5000UL) {  // if no ACK is coming, reset connection
     _tryOnError(TIMEOUT);
     _state = RESET;
     clearInput(_serial);


### PR DESCRIPTION
Hi,
I encountered problems with the reset being triggered too fast. Changing timeout for ACKs to 5seconds is fixing this.

Regards
makom