### PR TITLE
make getCollection() static

### DIFF
--- a/src/Datapoint.hpp
+++ b/src/Datapoint.hpp
@@ -73,7 +73,7 @@ class IDatapoint {
 
  public:
   // better not use this publicly
-  const std::vector<IDatapoint*>& getCollection() const { return _dps; }
+  static const std::vector<IDatapoint*>& getCollection() const { return _dps; }
 };
 
 template <class T>


### PR DESCRIPTION
making  getCollection() static makes more sense I think, cause _dps is static too.