### PR TITLE
Add pure esp-idf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 .pio
 .vscode
+.idea
 cov
 *cov.info
+build
+cmake-build-*
+sdkconfig
+managed_components
+dependencies.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ set(COMPONENT_ADD_INCLUDEDIRS
     "src" "src/Datapoint" "src/GWG" "src/VS1" "src/VS2" "src/Interface"
 )
 
-set(COMPONENT_REQUIRES
-    "arduino-esp32"
-)
-
 register_component()
 
 target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)

--- a/examples/esp-idf/CMakeLists.txt
+++ b/examples/esp-idf/CMakeLists.txt
@@ -1,0 +1,15 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.22)
+
+set(EXTRA_COMPONENT_DIRS
+    "main"
+    "../../"
+)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+project(VitoWifi)
+
+#target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)
+enable_language(C CXX)

--- a/examples/esp-idf/main/CMakeLists.txt
+++ b/examples/esp-idf/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+        SRCS "vitowifi-esp.cpp"
+        REQUIRES VitoWiFi esp_driver_uart
+        INCLUDE_DIRS "."
+)

--- a/examples/esp-idf/main/Kconfig.projbuild
+++ b/examples/esp-idf/main/Kconfig.projbuild
@@ -1,0 +1,33 @@
+menu "VitoWiFi Example Configuration"
+
+    orsource "$IDF_PATH/examples/common_components/env_caps/$IDF_TARGET/Kconfig.env_caps"
+
+    config EXAMPLE_UART_PORT_NUM
+        int "UART port number"
+        range 0 2 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S3
+        default 2 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S3
+        range 0 1
+        default 1
+        help
+            UART communication port number for the example.
+            See UART documentation for available port numbers.
+
+    config EXAMPLE_UART_RXD
+        int "UART RXD pin number"
+        range ENV_GPIO_RANGE_MIN ENV_GPIO_IN_RANGE_MAX
+        default 5 if !IDF_TARGET_ESP32H4
+        default 15 if IDF_TARGET_ESP32H4
+        help
+            GPIO number for UART RX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+    config EXAMPLE_UART_TXD
+        int "UART TXD pin number"
+        range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+        default 4 if !IDF_TARGET_ESP32H4
+        default 16 if IDF_TARGET_ESP32H4
+        help
+            GPIO number for UART TX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+endmenu

--- a/examples/esp-idf/main/idf_component.yaml
+++ b/examples/esp-idf/main/idf_component.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  VitoWiFi:
+    version: *
+    path: '../../../'

--- a/examples/esp-idf/main/vitowifi-esp.cpp
+++ b/examples/esp-idf/main/vitowifi-esp.cpp
@@ -123,9 +123,7 @@ void onError(VitoWiFi::OptolinkResult error, const VitoWiFi::Datapoint& request)
   }
 }
 
-uint64_t millis() {
-  return std::chrono::duration_cast<std::chrono::duration<uint32_t, std::milli>>(std::chrono::system_clock::now().time_since_epoch()).count();
-}
+#define millis() xTaskGetTickCount() * portTICK_PERIOD_MS
 
 void yieldIfNecessary(){
   static uint64_t lastYield = 0;

--- a/examples/esp-idf/main/vitowifi-esp.cpp
+++ b/examples/esp-idf/main/vitowifi-esp.cpp
@@ -1,0 +1,182 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+#include "esp_log.h"
+#include "sdkconfig.h"
+#include <VitoWiFi.h>
+#include <soc/uart_reg.h>
+
+/*
+This example is to show how you could build your own
+interface and serves as a compilation test
+*/
+
+#define VITOWIFI_TEST_TXD (CONFIG_EXAMPLE_UART_TXD)
+#define VITOWIFI_TEST_RXD (CONFIG_EXAMPLE_UART_RXD)
+#define VITOWIFI_TEST_RTS (UART_PIN_NO_CHANGE)
+#define VITOWIFI_TEST_CTS (UART_PIN_NO_CHANGE)
+
+#define VITOWIFI_UART_PORT_NUM  (uart_port_t)(CONFIG_EXAMPLE_UART_PORT_NUM)
+#define BUF_SIZE (1024)
+// Dummy class that has all the methods for VitoWiFi to work
+// but doesn't do anything in this case.
+// Use as skeleton for your own implementation
+class DummyInterface : VitoWiFiInternals::SerialInterface {
+ public:
+  bool begin() {
+    // prepare the interface
+    // optolink comm at 4800 baud, 8 bits, even parity and 2 stop bits
+    // called at VitoWiFi::begin()
+    /* Configure parameters of an UART driver,
+ * communication pins and install the driver */
+    uart_config_t uart_config = {
+      .baud_rate = 4800,
+      .data_bits = UART_DATA_8_BITS,
+      .parity = UART_PARITY_EVEN,
+      .stop_bits = UART_STOP_BITS_2,
+      .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+      .rx_flow_ctrl_thresh = 122,
+      .source_clk = UART_SCLK_DEFAULT,
+      .flags = {},
+    };
+    int intr_alloc_flags = 0;
+
+#if CONFIG_UART_ISR_IN_IRAM
+    intr_alloc_flags = ESP_INTR_FLAG_IRAM;
+#endif
+
+    ESP_ERROR_CHECK(uart_driver_install(VITOWIFI_UART_PORT_NUM, BUF_SIZE * 2, 0, 0, nullptr, intr_alloc_flags));
+    ESP_ERROR_CHECK(uart_param_config(VITOWIFI_UART_PORT_NUM, &uart_config));
+    ESP_ERROR_CHECK(uart_set_pin(VITOWIFI_UART_PORT_NUM, VITOWIFI_TEST_TXD, VITOWIFI_TEST_RXD, VITOWIFI_TEST_RTS, VITOWIFI_TEST_CTS));
+    return true;
+  }
+
+  void end() {
+    // stop the interface
+    // called at VitoWiFi::end()
+  }
+  std::size_t write(const uint8_t* data, uint8_t length) {
+    // tries to write `data` with length `length` to the interface
+    // returns the actually written data
+    return uart_write_bytes(VITOWIFI_UART_PORT_NUM, data, length);
+  }
+  uint8_t read() {
+    uint8_t c;
+    uart_read_bytes(VITOWIFI_UART_PORT_NUM, &c, 1, portMAX_DELAY);
+    // read one byte from the interface
+    // availability of data is checked first
+    return 0;
+  }
+  size_t available() {
+    size_t available = 0;
+    ESP_ERROR_CHECK(uart_get_buffered_data_len(VITOWIFI_UART_PORT_NUM, &available));
+    // check if data is available
+    return available;
+  }
+};
+
+// optolink on Dummy Interface, logging output on UART1 (connected to USB)
+DummyInterface dummyInterface;
+#define SERIAL1 dummyInterface
+TaskHandle_t loopTaskHandle = NULL;
+static const char *TAG = "VitoWiFi";
+
+VitoWiFi::VitoWiFi<VitoWiFi::VS2> vitoWiFi(&SERIAL1);
+bool readValues = false;
+uint8_t datapointIndex = 0;
+
+VitoWiFi::Datapoint datapoints[] = {
+  VitoWiFi::Datapoint("outsidetemp", 0x5525, 2, VitoWiFi::div10),
+  VitoWiFi::Datapoint("boilertemp", 0x0810, 2, VitoWiFi::div10),
+  VitoWiFi::Datapoint("pump", 0x2906, 1, VitoWiFi::noconv)
+};
+
+void onResponse(const VitoWiFi::PacketVS2& response, const VitoWiFi::Datapoint& request) {
+  // raw data can be accessed through the 'response' argument
+  ESP_LOGI(TAG, "Raw data received:");
+  ESP_LOG_BUFFER_HEX(TAG, response.data(), response.dataLength());
+
+  // the raw data can be decoded using the datapoint. Be sure to use the correct type
+  if (request.converter() == VitoWiFi::div10) {
+    float value = request.decode(response);
+    ESP_LOGI(TAG, "%s: %.1f", request.name(), value);
+  } else if (request.converter() == VitoWiFi::noconv) {
+    bool value = request.decode(response);
+    // alternatively, we can just cast response.data()[0] to bool
+    ESP_LOGI(TAG, "%s: %s", request.name(), value ? "ON" : "OFF");
+  }
+}
+
+void onError(VitoWiFi::OptolinkResult error, const VitoWiFi::Datapoint& request) {
+  ESP_LOGI(TAG, "Datapoint \"%s\" error: ", request.name());
+  if (error == VitoWiFi::OptolinkResult::TIMEOUT) {
+    ESP_LOGE(TAG, "timeout");
+  } else if (error == VitoWiFi::OptolinkResult::LENGTH) {
+    ESP_LOGE(TAG, "length");
+  } else if (error == VitoWiFi::OptolinkResult::NACK) {
+    ESP_LOGE(TAG, "nack");
+  } else if (error == VitoWiFi::OptolinkResult::CRC) {
+    ESP_LOGE(TAG, "crc");
+  } else if (error == VitoWiFi::OptolinkResult::ERROR) {
+    ESP_LOGE(TAG, "error");
+  }
+}
+
+uint64_t millis() {
+  return std::chrono::duration_cast<std::chrono::duration<uint32_t, std::milli>>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+void yieldIfNecessary(){
+  static uint64_t lastYield = 0;
+  uint64_t now = millis();
+  if((now - lastYield) > 2000) {
+    lastYield = now;
+    vTaskDelay(5); //delay 1 RTOS tick
+  }
+}
+
+
+void loop() {
+  static uint32_t lastMillis = 0;
+  if (millis() - lastMillis > 60000UL) {  // read all values every 60 seconds
+    lastMillis = millis();
+    readValues = true;
+    datapointIndex = 0;
+  }
+
+  if (readValues) {
+    if (vitoWiFi.read(datapoints[datapointIndex])) {
+      ++datapointIndex;
+    }
+    if (datapointIndex == 3) {
+      readValues = false;
+    }
+  }
+
+  vitoWiFi.loop();
+}
+
+extern "C"
+{
+  [[noreturn]] void loopTask(void *pvParameters) {
+    for(;;) {
+      yieldIfNecessary();
+      loop();
+    }
+  }
+
+  void app_main() {
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    ESP_LOGI(TAG, "Setting up vitoWiFi");
+
+    vitoWiFi.onResponse(onResponse);
+    vitoWiFi.onError(onError);
+    vitoWiFi.begin();
+
+    ESP_LOGI(TAG, "Setup finished");
+
+    xTaskCreate(loopTask, "loopTask", 8192, nullptr, 1, &loopTaskHandle);
+  }
+}
+

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,3 @@
-dependencies:
-  arduino-esp32: ">=3"
 description: Communicate with Viessmann boilers using the optolink for ESP8266 and ESP32
 url: https://github.com/bertmelis/VitoWiFi
 version: 3.0.0

--- a/src/GWG/GWG.cpp
+++ b/src/GWG/GWG.cpp
@@ -64,8 +64,9 @@ GWG::GWG(SoftwareSerial* interface)
   }
 }
 #endif
+#endif
 
-#else
+#if defined(__linux__)
 GWG::GWG(const char* interface)
 : _state(State::UNDEFINED)
 , _currentMillis(vw_millis())

--- a/src/GWG/GWG.h
+++ b/src/GWG/GWG.h
@@ -37,7 +37,8 @@ class GWG {
   #if defined(ARDUINO_ARCH_ESP8266)
   explicit GWG(SoftwareSerial* interface);
   #endif
-  #else
+  #endif
+  #if defined(__linux__)
   explicit GWG(const char* interface);
   #endif
   template<class C>

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -12,7 +12,7 @@ the LICENSE file.
 #include <cstdint>
 #include <cstddef>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(ESP_PLATFORM)
   #include <chrono>  // NOLINT [build/c++11]
   #define vw_millis() std::chrono::duration_cast<std::chrono::duration<uint32_t, std::milli>>(std::chrono::system_clock::now().time_since_epoch()).count()
 #else

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -12,11 +12,16 @@ the LICENSE file.
 #include <cstdint>
 #include <cstddef>
 
-#if defined(__linux__) || defined(ESP_PLATFORM)
+#if defined(__linux__)
   #include <chrono>  // NOLINT [build/c++11]
   #define vw_millis() std::chrono::duration_cast<std::chrono::duration<uint32_t, std::milli>>(std::chrono::system_clock::now().time_since_epoch()).count()
-#else
+#elif defined(ESP_PLATFORM)
+  #include "freertos/FreeRTOS.h"
+  #define vw_millis() xTaskGetTickCount() * portTICK_PERIOD_MS
+#elif defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   #define vw_millis() millis()
+#else
+#error "Unsupported target platform"
 #endif
 
 #define vw_abort() abort()

--- a/src/VS1/VS1.cpp
+++ b/src/VS1/VS1.cpp
@@ -65,7 +65,9 @@ VS1::VS1(SoftwareSerial* interface)
 }
 #endif
 
-#else
+#endif
+
+#if defined(__linux__)
 VS1::VS1(const char* interface)
 : _state(State::UNDEFINED)
 , _currentMillis(vw_millis())

--- a/src/VS1/VS1.h
+++ b/src/VS1/VS1.h
@@ -37,7 +37,8 @@ class VS1 {
   #if defined(ARDUINO_ARCH_ESP8266)
   explicit VS1(SoftwareSerial* interface);
   #endif
-  #else
+  #endif
+  #if defined(__linux__)
   explicit VS1(const char* interface);
   #endif
   template<class C>

--- a/src/VS2/VS2.cpp
+++ b/src/VS2/VS2.cpp
@@ -52,8 +52,9 @@ VS2::VS2(SoftwareSerial* interface)
   }
 }
 #endif
+#endif
 
-#else
+#if defined(__linux__)
 VS2::VS2(const char* interface)
 : _state(State::UNDEFINED)
 , _currentMillis(vw_millis())

--- a/src/VS2/VS2.h
+++ b/src/VS2/VS2.h
@@ -37,7 +37,8 @@ class VS2 {
   #if defined(ARDUINO_ARCH_ESP8266)
   explicit VS2(SoftwareSerial* interface);
   #endif
-  #else
+  #endif
+  #if defined(__linux__)
   explicit VS2(const char* interface);
   #endif
   template<class C>


### PR DESCRIPTION
The current implementation always enforces Arduino ESP32 component. This PR adds pure esp-idf support filling the gaps.